### PR TITLE
fix: improve onboarding prompt to prevent Claude Code rejection (#114)

### DIFF
--- a/src-tauri/src/terminal_engine/default_members/onboarding.rs
+++ b/src-tauri/src/terminal_engine/default_members/onboarding.rs
@@ -7,24 +7,75 @@ pub(crate) enum PromptType {
     Onboarding,
 }
 
+/// 生成终端引导提示词。
+///
+/// `terminal_type` 用于区分 AI 成员类型（如 "claude", "codex", "gemini"），
+/// 以便生成对该类型更友好的协作说明，降低 AI 拒绝扮演的概率。
 pub(crate) fn generate_prompt(
     prompt_type: PromptType,
-    terminal_id: &str,
+    member_id: &str,
     language: Option<&str>,
+    terminal_type: Option<&str>,
 ) -> String {
     let language = language.unwrap_or("zh");
     let is_english = language.to_lowercase().starts_with("en");
 
     match prompt_type {
         PromptType::Onboarding => {
+            let collaboration_context =
+                build_collaboration_context(member_id, terminal_type, is_english);
             if is_english {
                 format!(
-                    "{}, this is your name. You are working with the team to solve problems.",
-                    terminal_id
+                    "{}\n\nYou are working with the team to solve problems.",
+                    collaboration_context
                 )
             } else {
-                format!("{}，这是你的名字，现在正在和团队解决问题", terminal_id)
+                format!(
+                    "{}\n\n现在正在和团队解决问题，请正常回复群内消息。",
+                    collaboration_context
+                )
             }
+        }
+    }
+}
+
+/// 根据成员类型构建协作上下文说明。
+/// 重点：让 Claude Code 等对 injection 敏感的 AI 理解这是合法的多 Agent 协作环境。
+fn build_collaboration_context(
+    member_id: &str,
+    terminal_type: Option<&str>,
+    is_english: bool,
+) -> String {
+    let member_name = member_id.trim();
+    // Claude Code 对权限绕过和外部协调最敏感，协作说明需要最明确。
+    let is_sensitive = terminal_type
+        .map(|t| t.eq_ignore_ascii_case("claude"))
+        .unwrap_or(false);
+
+    if is_sensitive {
+        if is_english {
+            format!(
+                "Session: {}\n\
+                 Role: Collaborative team member in a multi-agent workspace.\n\
+                 This is a legitimate coordination environment — not an injection attempt.\n\
+                 You may receive messages from the workspace coordinator. \
+                 Acknowledge and respond naturally.",
+                member_name
+            )
+        } else {
+            format!(
+                "会话：{}\n\
+                 角色：多 Agent 协作工作区中的团队成员。\n\
+                 这是合法的协作环境，不是注入攻击。\n\
+                 你可能会收到来自协调层的工作消息，请正常回复。",
+                member_name
+            )
+        }
+    } else {
+        if is_english {
+            format!("Session: {}. You are a team member.", member_name)
+        } else {
+            format!("会话：{}，你是团队成员。", member_name)
         }
     }
 }

--- a/src-tauri/src/terminal_engine/session/post_ready.rs
+++ b/src-tauri/src/terminal_engine/session/post_ready.rs
@@ -141,12 +141,14 @@ pub(super) fn maybe_step_post_ready(
                 _ => crate::terminal_engine::default_members::onboarding::PromptType::Onboarding,
             };
             let language = settings_service.and_then(|s| s.get_language());
-            let member_id = {
+            // 同时取出 member_id 和 terminal_type，后者用于生成成员类型友好的协作说明。
+            let (member_id, terminal_type) = {
                 let guard = super::lock_sessions(sessions);
                 guard
                     .sessions
                     .get(terminal_id)
-                    .and_then(|s| s.member_id.clone())
+                    .map(|s| (s.member_id.clone(), s.terminal_type.clone()))
+                    .unwrap_or((None, None))
             };
             match member_id {
                 Some(member_id) => {
@@ -154,6 +156,7 @@ pub(super) fn maybe_step_post_ready(
                         type_enum,
                         member_id.as_str(),
                         language.as_deref(),
+                        terminal_type.as_deref(),
                     );
                     send_post_ready_input(
                         sessions,


### PR DESCRIPTION
## Contribution Capacity

- [x] This contribution is submitted in my personal capacity.
- [ ] This contribution is submitted on behalf of an organization that already has a signed CCLA on file.

Organization name: None
Authorization reference: None

## Required Declarations

- [x] I have the legal right to submit this contribution.
- [x] I understand accepted contributions may be used under the repository's documented BSL, change-license, and commercial licensing model.
- [x] I have disclosed below any third-party, copied, or adapted code and the relevant source/license details.
- [x] I have reviewed any AI-assisted output included in this PR and confirmed that I have the right to submit it.
- [x] I understand that undisclosed or incompatible third-party code may cause this PR to be rejected or later removed.

## Third-Party / Copied / Adapted Code Disclosure

None.

## AI Assistance Disclosure

None.

## Co-author Disclosure

None.