### PR TITLE
Normalize imported skills and block suffixed duplicates

### DIFF
--- a/src-tauri/src/ui_gateway/mod.rs
+++ b/src-tauri/src/ui_gateway/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod platform;
 pub(crate) mod project_skills;
 pub(crate) mod project_data;
 pub(crate) mod project_members;
+pub(crate) mod skill_layout;
 pub(crate) mod skills;
 pub(crate) mod terminal;
 pub(crate) mod terminal_events;

--- a/src-tauri/src/ui_gateway/project_skills.rs
+++ b/src-tauri/src/ui_gateway/project_skills.rs
@@ -2,12 +2,13 @@
 
 use std::{
   fs,
-  path::{Path, PathBuf},
+  path::PathBuf,
 };
 
 use serde::Serialize;
 use tauri::{AppHandle, Manager};
 
+use super::skill_layout::{ensure_openai_interface_file, inspect_skill_folder};
 use crate::runtime::{storage, StorageManager};
 
 #[derive(Serialize)]
@@ -95,6 +96,9 @@ pub(crate) fn project_skills_link(
     return Err("selected skill is not inside the skills library".to_string());
   }
 
+  let layout = inspect_skill_folder(&source_canonical)?;
+  ensure_openai_interface_file(&source_canonical, &layout)?;
+
   if skills_root.exists() {
     let entries = fs::read_dir(&skills_root)
       .map_err(|err| format!("failed to read project skills directory: {err}"))?;
@@ -122,23 +126,31 @@ pub(crate) fn project_skills_link(
       if target_canonical == source_canonical {
         return Err("skill is already linked to this workspace".to_string());
       }
+      let entry_name = entry
+        .file_name()
+        .to_str()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| entry.file_name().to_string_lossy().to_string());
+      if entry_name == layout.canonical_name {
+        return Err(format!(
+          "workspace already has a project skill named '{}'; remove the old link instead of creating a suffixed copy",
+          layout.canonical_name
+        ));
+      }
     }
   }
 
-  let folder_name = source_canonical
-    .file_name()
-    .and_then(|name| name.to_str())
-    .ok_or_else(|| "selected skill folder name is not valid UTF-8".to_string())?;
-  let destination = unique_destination(&skills_root, folder_name);
+  let destination = skills_root.join(&layout.canonical_name);
+  if destination.exists() {
+    return Err(format!(
+      "project skill destination '{}' already exists",
+      layout.canonical_name
+    ));
+  }
   storage::create_dir_symlink(&source_canonical, &destination)?;
 
-  let name = destination
-    .file_name()
-    .and_then(|value| value.to_str())
-    .map(|value| value.to_string())
-    .unwrap_or_else(|| destination.file_name().unwrap().to_string_lossy().to_string());
   Ok(ProjectSkillLink {
-    name,
+    name: layout.canonical_name,
     link_path: destination.to_string_lossy().to_string(),
     target_path: source_canonical.to_string_lossy().to_string(),
   })
@@ -170,19 +182,4 @@ pub(crate) fn project_skills_unlink(
     return Err("project skill is not a symlink".to_string());
   }
   storage::remove_symlink(&target_path)
-}
-
-fn unique_destination(root: &Path, folder_name: &str) -> PathBuf {
-  let base = root.join(folder_name);
-  if !base.exists() {
-    return base;
-  }
-  let mut index = 1;
-  loop {
-    let candidate = root.join(format!("{folder_name}-{index}"));
-    if !candidate.exists() {
-      return candidate;
-    }
-    index += 1;
-  }
 }

--- a/src-tauri/src/ui_gateway/skill_layout.rs
+++ b/src-tauri/src/ui_gateway/skill_layout.rs
@@ -1,0 +1,270 @@
+//! Shared skill layout validation and lightweight normalization helpers.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SkillLayout {
+    pub(crate) canonical_name: String,
+    pub(crate) description: String,
+    pub(crate) display_name: String,
+}
+
+pub(crate) fn inspect_skill_folder(skill_root: &Path) -> Result<SkillLayout, String> {
+    if !skill_root.exists() {
+        return Err("skill folder does not exist".to_string());
+    }
+    if !skill_root.is_dir() {
+        return Err("skill path is not a folder".to_string());
+    }
+
+    let skill_md_path = skill_root.join("SKILL.md");
+    if !skill_md_path.exists() {
+        return Err("skill folder must contain SKILL.md".to_string());
+    }
+    if !skill_md_path.is_file() {
+        return Err("SKILL.md must be a file".to_string());
+    }
+
+    let contents = fs::read_to_string(&skill_md_path)
+        .map_err(|err| format!("failed to read SKILL.md: {err}"))?;
+    let frontmatter = parse_skill_frontmatter(&contents)?;
+    if !is_kebab_case(&frontmatter.name) {
+        return Err("SKILL.md frontmatter name must be lowercase kebab-case".to_string());
+    }
+    let display_name =
+        extract_heading(&contents).unwrap_or_else(|| title_case_name(&frontmatter.name));
+
+    Ok(SkillLayout {
+        canonical_name: frontmatter.name,
+        description: frontmatter.description,
+        display_name,
+    })
+}
+
+pub(crate) fn ensure_openai_interface_file(
+    skill_root: &Path,
+    layout: &SkillLayout,
+) -> Result<PathBuf, String> {
+    let openai_path = skill_root.join("agents").join("openai.yaml");
+    if openai_path.exists() {
+        if !openai_path.is_file() {
+            return Err("agents/openai.yaml must be a file".to_string());
+        }
+        return Ok(openai_path);
+    }
+
+    if let Some(parent) = openai_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create agents directory: {err}"))?;
+    }
+
+    let contents = format!(
+    "interface:\n  display_name: \"{}\"\n  short_description: \"{}\"\n  default_prompt: \"Use ${} when this skill is needed.\"\n",
+    yaml_escape(&layout.display_name),
+    yaml_escape(&truncate_text(&layout.description, 160)),
+    yaml_escape(&layout.canonical_name),
+  );
+    fs::write(&openai_path, contents)
+        .map_err(|err| format!("failed to write agents/openai.yaml: {err}"))?;
+    Ok(openai_path)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SkillFrontmatter {
+    name: String,
+    description: String,
+}
+
+fn parse_skill_frontmatter(contents: &str) -> Result<SkillFrontmatter, String> {
+    let mut lines = contents.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return Err("SKILL.md must start with YAML frontmatter".to_string());
+    }
+
+    let mut closed = false;
+    let mut name = None;
+    let mut description = None;
+    for line in lines.by_ref() {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            closed = true;
+            break;
+        }
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some((key, raw_value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let value = normalize_yaml_scalar(raw_value);
+        match key.trim() {
+            "name" => name = Some(value),
+            "description" => description = Some(value),
+            _ => {}
+        }
+    }
+
+    if !closed {
+        return Err("SKILL.md frontmatter is not closed".to_string());
+    }
+
+    let name = name
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "SKILL.md frontmatter must include name".to_string())?;
+    let description = description
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "SKILL.md frontmatter must include description".to_string())?;
+
+    Ok(SkillFrontmatter { name, description })
+}
+
+fn normalize_yaml_scalar(raw: &str) -> String {
+    let value = raw.trim();
+    let unquoted = value
+        .strip_prefix('"')
+        .and_then(|rest| rest.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|rest| rest.strip_suffix('\''))
+        })
+        .unwrap_or(value);
+    unquoted.trim().to_string()
+}
+
+fn extract_heading(contents: &str) -> Option<String> {
+    let mut lines = contents.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return None;
+    }
+    for line in lines.by_ref() {
+        if line.trim() == "---" {
+            break;
+        }
+    }
+    for line in lines {
+        let trimmed = line.trim();
+        if let Some(title) = trimmed.strip_prefix("# ") {
+            let title = title.trim();
+            if !title.is_empty() {
+                return Some(title.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn is_kebab_case(value: &str) -> bool {
+    if value.is_empty() || value.starts_with('-') || value.ends_with('-') || value.contains("--") {
+        return false;
+    }
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+}
+
+fn title_case_name(value: &str) -> String {
+    value
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => {
+                    let mut word = String::new();
+                    word.push(first.to_ascii_uppercase());
+                    word.push_str(chars.as_str());
+                    word
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn truncate_text(value: &str, max_len: usize) -> String {
+    let trimmed = value.trim();
+    if trimmed.chars().count() <= max_len {
+        return trimmed.to_string();
+    }
+    let truncated = trimmed
+        .chars()
+        .take(max_len.saturating_sub(1))
+        .collect::<String>();
+    format!("{truncated}…")
+}
+
+fn yaml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_openai_interface_file, inspect_skill_folder};
+    use std::{env, fs, path::PathBuf};
+    use ulid::Ulid;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let path = env::temp_dir().join(format!("golutra-{name}-{}", Ulid::new()));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    #[test]
+    fn inspect_skill_folder_reads_frontmatter_and_heading() {
+        let dir = temp_dir("skill-layout");
+        fs::write(
+      dir.join("SKILL.md"),
+      "---\nname: token-compact\ndescription: Keep shared channels compact.\n---\n\n# Token Compact\n",
+    )
+    .expect("write skill file");
+
+        let layout = inspect_skill_folder(&dir).expect("inspect skill layout");
+        assert_eq!(layout.canonical_name, "token-compact");
+        assert_eq!(layout.description, "Keep shared channels compact.");
+        assert_eq!(layout.display_name, "Token Compact");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inspect_skill_folder_rejects_invalid_name() {
+        let dir = temp_dir("skill-layout-invalid");
+        fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: TokenCompact\ndescription: Keep shared channels compact.\n---\n",
+        )
+        .expect("write skill file");
+
+        let error = inspect_skill_folder(&dir).expect_err("invalid kebab-case name");
+        assert!(error.contains("kebab-case"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn ensure_openai_interface_file_bootstraps_missing_metadata() {
+        let dir = temp_dir("skill-layout-bootstrap");
+        fs::write(
+      dir.join("SKILL.md"),
+      "---\nname: token-compact\ndescription: Keep shared channels compact.\n---\n\n# Token Compact\n",
+    )
+    .expect("write skill file");
+
+        let layout = inspect_skill_folder(&dir).expect("inspect skill layout");
+        let openai_path =
+            ensure_openai_interface_file(&dir, &layout).expect("create openai metadata file");
+        let contents = fs::read_to_string(openai_path).expect("read openai metadata file");
+        assert!(contents.contains("display_name: \"Token Compact\""));
+        assert!(contents.contains("short_description: \"Keep shared channels compact.\""));
+        assert!(
+            contents.contains("default_prompt: \"Use $token-compact when this skill is needed.\"")
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src-tauri/src/ui_gateway/skills.rs
+++ b/src-tauri/src/ui_gateway/skills.rs
@@ -2,7 +2,7 @@
 
 use std::{
   fs,
-  path::{Path, PathBuf},
+  path::PathBuf,
 };
 
 use serde::Serialize;
@@ -10,6 +10,7 @@ use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::DialogExt;
 
 use super::app::open_folder_in_file_manager;
+use super::skill_layout::{ensure_openai_interface_file, inspect_skill_folder};
 use crate::runtime::{storage, StorageManager};
 
 #[derive(Serialize)]
@@ -52,12 +53,6 @@ pub(crate) async fn skills_import_folder(
       return Err("selected path is not a folder".to_string());
     }
 
-    let folder_name = source_path
-      .file_name()
-      .and_then(|name| name.to_str())
-      .ok_or_else(|| "selected folder name is not valid UTF-8".to_string())?
-      .to_string();
-
     let storage = app.state::<StorageManager>();
     let skills_root = storage::resolve_app_data_path(storage.inner(), "skills")?;
     fs::create_dir_all(&skills_root)
@@ -72,11 +67,23 @@ pub(crate) async fn skills_import_folder(
       return Err("selected folder is already inside the skills library".to_string());
     }
 
-    let destination = unique_destination(&skills_root, &folder_name);
-    storage::copy_dir_recursive(&source_path, &destination)?;
+    let layout = inspect_skill_folder(&source_canonical)?;
+    let destination = skills_root.join(&layout.canonical_name);
+    if destination.exists() {
+      return Err(format!(
+        "skill '{}' already exists in the skills library; update it in place instead of importing a suffixed copy",
+        layout.canonical_name
+      ));
+    }
+
+    storage::copy_dir_recursive(&source_canonical, &destination)?;
+    if let Err(err) = ensure_openai_interface_file(&destination, &layout) {
+      let _ = storage::remove_dir_recursive(&destination);
+      return Err(err);
+    }
 
     Ok(Some(SkillFolderImportResult {
-      folder_name,
+      folder_name: layout.canonical_name,
       dest_path: destination.to_string_lossy().to_string(),
     }))
   }
@@ -140,19 +147,4 @@ pub(crate) fn skills_open_folder(app: AppHandle, path: String) -> Result<(), Str
     return Err("skill folder is outside the skills library".to_string());
   }
   open_folder_in_file_manager(&target_path)
-}
-
-fn unique_destination(root: &Path, folder_name: &str) -> PathBuf {
-  let base = root.join(folder_name);
-  if !base.exists() {
-    return base;
-  }
-  let mut index = 1;
-  loop {
-    let candidate = root.join(format!("{folder_name}-{index}"));
-    if !candidate.exists() {
-      return candidate;
-    }
-    index += 1;
-  }
 }

--- a/src/features/SkillStore.vue
+++ b/src/features/SkillStore.vue
@@ -264,6 +264,10 @@ const filters = [
 
 const { t } = useI18n();
 const canOpenSkillPath = isTauri();
+const formatError = (error: unknown) => (error instanceof Error ? error.message : String(error));
+const showActionError = (title: string, error: unknown) => {
+  window.alert(`${title}\n\n${formatError(error)}`);
+};
 
 const handleInstall = (id: number) => {
   void installSkill(id);
@@ -316,6 +320,7 @@ const handleImportFolder = async () => {
     console.info('Imported skill folder.', result);
   } catch (error) {
     console.error('Failed to import skill folder.', error);
+    showActionError(t('skills.library.importTitle'), error);
   } finally {
     importingFolder.value = false;
   }
@@ -331,6 +336,7 @@ const handleRemoveFolder = async (folder: { id: string; name: string; path: stri
     await removeImportedSkillFolder(folder.id);
   } catch (error) {
     console.error('Failed to remove skill folder.', error);
+    showActionError(t('common.remove'), error);
   } finally {
     removingFolderId.value = null;
   }

--- a/src/features/chat/modals/SkillManagementModal.vue
+++ b/src/features/chat/modals/SkillManagementModal.vue
@@ -393,6 +393,10 @@ const navigationStore = useNavigationStore();
 const { setActiveTab, setSkillStoreTab } = navigationStore;
 const channelLabel = computed(() => `#${defaultChannelName.value}`);
 const canOpenSkillPath = isTauri();
+const formatError = (error: unknown) => (error instanceof Error ? error.message : String(error));
+const showActionError = (title: string, error: unknown) => {
+  window.alert(`${title}\n\n${formatError(error)}`);
+};
 
 const librarySkills = ref(createLibrarySkills());
 const installedLibrarySkills = computed(() =>
@@ -475,6 +479,7 @@ const loadProjectSkillLinks = async () => {
     projectSkillLinks.value = await listProjectSkillLinks(workspace.path);
   } catch (error) {
     console.error('Failed to load project skill links.', error);
+    showActionError(t('skills.project.title'), error);
   } finally {
     loadingProjectSkills.value = false;
   }
@@ -526,6 +531,7 @@ const handleImportFolder = async () => {
     console.info('Imported skill folder.', result);
   } catch (error) {
     console.error('Failed to import skill folder.', error);
+    showActionError(t('skills.library.importTitle'), error);
   } finally {
     importingFolder.value = false;
   }
@@ -546,6 +552,7 @@ const handleLinkProjectSkill = async (folder: { id: string; path: string }) => {
     closeProjectSkillPicker();
   } catch (error) {
     console.error('Failed to link project skill.', error);
+    showActionError(t('skills.project.import'), error);
   } finally {
     linkingSkillId.value = null;
   }
@@ -571,6 +578,7 @@ const handleRemoveFolder = async (folder: { id: string; name: string; path: stri
     await removeImportedSkillFolder(folder.id);
   } catch (error) {
     console.error('Failed to remove skill folder.', error);
+    showActionError(t('common.remove'), error);
   } finally {
     removingFolderId.value = null;
   }
@@ -594,6 +602,7 @@ const handleRemoveProjectSkill = async (link: { name: string }) => {
     projectSkillLinks.value = projectSkillLinks.value.filter((item) => item.name !== link.name);
   } catch (error) {
     console.error('Failed to unlink project skill.', error);
+    showActionError(t('skills.project.removeConfirmTitle'), error);
   } finally {
     unlinkingSkillName.value = null;
   }


### PR DESCRIPTION
## Summary
- normalize imported skills around the canonical `name` declared in `SKILL.md`
- block auto-created suffixed copies like `-1` during global import and project linking
- auto-bootstrap `agents/openai.yaml` when a valid skill is missing UI metadata
- surface import/link failures in the skill UI instead of only logging to the console

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `corepack pnpm exec eslint "src/features/SkillStore.vue" "src/features/chat/modals/SkillManagementModal.vue"`

## Contribution Capacity

- [x] This contribution is submitted in my personal capacity.
- [ ] This contribution is submitted on behalf of an organization that already has a signed CCLA on file.

Organization name: None
Authorization reference: None

## Required Declarations

- [x] I have the legal right to submit this contribution.
- [x] I understand accepted contributions may be used under the repository's documented BSL, change-license, and commercial licensing model.
- [x] I have disclosed below any third-party, copied, or adapted code and the relevant source/license details.
- [x] I have reviewed any AI-assisted output included in this PR and confirmed that I have the right to submit it.
- [x] I understand that undisclosed or incompatible third-party code may cause this PR to be rejected or later removed.

## Third-Party / Copied / Adapted Code Disclosure

None.

## AI Assistance Disclosure

Prepared with AI assistance and reviewed before submission.

## Co-author Disclosure

None.