### PR TITLE
Reconcile global skill registry from disk on startup

### DIFF
--- a/src-tauri/src/ui_gateway/commands.rs
+++ b/src-tauri/src/ui_gateway/commands.rs
@@ -91,6 +91,7 @@ pub(crate) fn export_commands() -> impl Fn(Invoke) -> bool + Send + Sync + 'stat
     project_skills::project_skills_list,
     project_skills::project_skills_link,
     project_skills::project_skills_unlink,
+    skills::skills_list_folders,
     skills::skills_import_folder,
     skills::skills_remove_folder,
     skills::skills_open_folder

--- a/src-tauri/src/ui_gateway/skills.rs
+++ b/src-tauri/src/ui_gateway/skills.rs
@@ -19,6 +19,47 @@ pub(crate) struct SkillFolderImportResult {
   dest_path: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SkillFolderEntry {
+  name: String,
+  path: String,
+}
+
+#[tauri::command]
+pub(crate) fn skills_list_folders(app: AppHandle) -> Result<Vec<SkillFolderEntry>, String> {
+  let storage = app.state::<StorageManager>();
+  let skills_root = storage::resolve_app_data_path(storage.inner(), "skills")?;
+  if !skills_root.exists() {
+    return Ok(Vec::new());
+  }
+  if !skills_root.is_dir() {
+    return Err("skills library is not a directory".to_string());
+  }
+
+  let entries =
+    fs::read_dir(&skills_root).map_err(|err| format!("failed to read skills directory: {err}"))?;
+  let mut results = Vec::new();
+  for entry in entries {
+    let entry = entry.map_err(|err| format!("failed to read skill entry: {err}"))?;
+    let path = entry.path();
+    if !path.is_dir() {
+      continue;
+    }
+    let name = entry
+      .file_name()
+      .to_str()
+      .map(|value| value.to_string())
+      .unwrap_or_else(|| entry.file_name().to_string_lossy().to_string());
+    results.push(SkillFolderEntry {
+      name,
+      path: path.to_string_lossy().to_string(),
+    });
+  }
+  results.sort_by(|left, right| left.name.cmp(&right.name));
+  Ok(results)
+}
+
 #[tauri::command]
 pub(crate) async fn skills_import_folder(
   app: AppHandle,

--- a/src/features/global/globalData.ts
+++ b/src/features/global/globalData.ts
@@ -1,0 +1,139 @@
+export type ImportedSkillFolder = {
+  id: string;
+  name: string;
+  path: string;
+  addedAt: number;
+};
+
+export type GlobalData = {
+  version: number;
+  installedSkills: number[];
+  installedPlugins: number[];
+  importedSkillFolders: ImportedSkillFolder[];
+};
+
+export type SkillFolderSource = {
+  name: string;
+  path: string;
+};
+
+export const buildDefaultGlobalData = (): GlobalData => ({
+  version: 1,
+  installedSkills: [],
+  installedPlugins: [],
+  importedSkillFolders: []
+});
+
+const normalizeFolderName = (name: string, path: string) =>
+  name.trim() || path.split(/[\\/]/).filter(Boolean).pop() || path;
+
+export const normalizeImportedSkillFolders = (candidate?: unknown): ImportedSkillFolder[] => {
+  if (!Array.isArray(candidate)) {
+    return [];
+  }
+  const folders: ImportedSkillFolder[] = [];
+  const seenPaths = new Set<string>();
+  for (const entry of candidate) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const record = entry as Partial<ImportedSkillFolder>;
+    const path = typeof record.path === 'string' ? record.path.trim() : '';
+    if (!path || seenPaths.has(path)) {
+      continue;
+    }
+    const name = normalizeFolderName(typeof record.name === 'string' ? record.name : '', path);
+    const id = typeof record.id === 'string' && record.id.trim() ? record.id.trim() : path;
+    const addedAt =
+      typeof record.addedAt === 'number' && Number.isFinite(record.addedAt)
+        ? record.addedAt
+        : 0;
+    folders.push({ id, name, path, addedAt });
+    seenPaths.add(path);
+  }
+  return folders;
+};
+
+export const normalizeGlobalData = (candidate?: Partial<GlobalData>): GlobalData => {
+  const defaults = buildDefaultGlobalData();
+  const version = Number(candidate?.version);
+  const installedSkills = Array.isArray(candidate?.installedSkills)
+    ? candidate?.installedSkills
+    : defaults.installedSkills;
+  const installedPlugins = Array.isArray(candidate?.installedPlugins)
+    ? candidate?.installedPlugins
+    : defaults.installedPlugins;
+  const importedSkillFolders = normalizeImportedSkillFolders(candidate?.importedSkillFolders);
+  return {
+    version: Number.isFinite(version) && version > 0 ? version : defaults.version,
+    installedSkills,
+    installedPlugins,
+    importedSkillFolders
+  };
+};
+
+const normalizeSkillFolderSources = (candidate?: SkillFolderSource[] | null): SkillFolderSource[] => {
+  if (!Array.isArray(candidate)) {
+    return [];
+  }
+  const folders: SkillFolderSource[] = [];
+  const seenPaths = new Set<string>();
+  for (const entry of candidate) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const path = typeof entry.path === 'string' ? entry.path.trim() : '';
+    if (!path || seenPaths.has(path)) {
+      continue;
+    }
+    const name = normalizeFolderName(typeof entry.name === 'string' ? entry.name : '', path);
+    folders.push({ name, path });
+    seenPaths.add(path);
+  }
+  return folders;
+};
+
+export const reconcileImportedSkillFolders = (
+  storedCandidate: unknown,
+  actualCandidate: SkillFolderSource[] | null | undefined,
+  now = Date.now()
+): ImportedSkillFolder[] => {
+  const stored = normalizeImportedSkillFolders(storedCandidate);
+  const actual = normalizeSkillFolderSources(actualCandidate);
+  if (actual.length === 0 && !Array.isArray(actualCandidate)) {
+    return stored;
+  }
+
+  const storedByPath = new Map(stored.map((folder) => [folder.path, folder] as const));
+  const storedByName = new Map(stored.map((folder) => [folder.name.toLowerCase(), folder] as const));
+
+  return actual.map((folder) => {
+    const existing =
+      storedByPath.get(folder.path) ?? storedByName.get(folder.name.toLowerCase()) ?? null;
+    const addedAt = existing && existing.addedAt > 0 ? existing.addedAt : now;
+    return {
+      id: folder.path,
+      name: folder.name,
+      path: folder.path,
+      addedAt
+    };
+  });
+};
+
+export const sameImportedSkillFolders = (
+  left: ImportedSkillFolder[],
+  right: ImportedSkillFolder[]
+): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((folder, index) => {
+    const other = right[index];
+    return (
+      folder.id === other.id &&
+      folder.name === other.name &&
+      folder.path === other.path &&
+      folder.addedAt === other.addedAt
+    );
+  });
+};

--- a/src/features/global/globalStore.ts
+++ b/src/features/global/globalStore.ts
@@ -1,94 +1,31 @@
-// 全局数据存储：用于安装状态等跨工作区的应用级数据。
 import { computed, ref } from 'vue';
 import { acceptHMRUpdate, defineStore } from 'pinia';
+
 import { readAppData, writeAppData } from '@/shared/tauri/storage';
+import { listSkillFolders } from '@/features/skills/skillsBridge';
 
-type GlobalData = {
-  version: number;
-  installedSkills: number[];
-  installedPlugins: number[];
-  importedSkillFolders: ImportedSkillFolder[];
-};
+import {
+  type GlobalData,
+  type ImportedSkillFolder,
+  buildDefaultGlobalData,
+  normalizeGlobalData,
+  reconcileImportedSkillFolders,
+  sameImportedSkillFolders
+} from './globalData';
 
-export type ImportedSkillFolder = {
-  id: string;
-  name: string;
-  path: string;
-  addedAt: number;
-};
-
-// 应用级数据文件名，与后端存储约定保持一致。
 const GLOBAL_DATA_PATH = 'global-data.json';
-
-const buildDefaultGlobalData = (): GlobalData => ({
-  version: 1,
-  installedSkills: [],
-  installedPlugins: [],
-  importedSkillFolders: []
-});
-
-const normalizeImportedSkillFolders = (candidate?: unknown): ImportedSkillFolder[] => {
-  if (!Array.isArray(candidate)) {
-    return [];
-  }
-  const folders: ImportedSkillFolder[] = [];
-  const seenPaths = new Set<string>();
-  for (const entry of candidate) {
-    if (!entry || typeof entry !== 'object') {
-      continue;
-    }
-    const record = entry as Partial<ImportedSkillFolder>;
-    const path = typeof record.path === 'string' ? record.path.trim() : '';
-    if (!path || seenPaths.has(path)) {
-      continue;
-    }
-    const name =
-      typeof record.name === 'string' && record.name.trim()
-        ? record.name.trim()
-        : path.split(/[\\/]/).filter(Boolean).pop() ?? path;
-    const id = typeof record.id === 'string' && record.id.trim() ? record.id.trim() : path;
-    const addedAt =
-      typeof record.addedAt === 'number' && Number.isFinite(record.addedAt)
-        ? record.addedAt
-        : 0;
-    folders.push({ id, name, path, addedAt });
-    seenPaths.add(path);
-  }
-  return folders;
-};
-
-const normalizeGlobalData = (candidate?: Partial<GlobalData>): GlobalData => {
-  const defaults = buildDefaultGlobalData();
-  const version = Number(candidate?.version);
-  const installedSkills = Array.isArray(candidate?.installedSkills) ? candidate?.installedSkills : defaults.installedSkills;
-  const installedPlugins = Array.isArray(candidate?.installedPlugins) ? candidate?.installedPlugins : defaults.installedPlugins;
-  const importedSkillFolders = normalizeImportedSkillFolders(candidate?.importedSkillFolders);
-  return {
-    version: Number.isFinite(version) && version > 0 ? version : defaults.version,
-    installedSkills,
-    installedPlugins,
-    importedSkillFolders
-  };
-};
 
 const formatError = (error: unknown) => (error instanceof Error ? error.message : String(error));
 
-/**
- * 全局数据存储。
- * 输入：hydrate 初始化与安装/移除操作。
- * 输出：已安装列表与操作函数。
- */
+const sameNumberArray = (left: number[], right: number[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
 export const useGlobalStore = defineStore('global', () => {
   const globalData = ref<GlobalData>(buildDefaultGlobalData());
   const loadingGlobal = ref(false);
   const loadedGlobal = ref(false);
   const globalError = ref<string | null>(null);
 
-  /**
-   * 读取并初始化全局数据，仅执行一次。
-   * 输入：无。
-   * 输出：更新 globalData；失败时记录错误信息。
-   */
   const hydrate = async () => {
     if (loadingGlobal.value || loadedGlobal.value) return;
     loadingGlobal.value = true;
@@ -96,14 +33,31 @@ export const useGlobalStore = defineStore('global', () => {
     try {
       const stored = await readAppData<GlobalData>(GLOBAL_DATA_PATH);
       const normalized = normalizeGlobalData(stored ?? undefined);
-      globalData.value = normalized;
+      let actualSkillFolders = null;
+      try {
+        actualSkillFolders = await listSkillFolders();
+      } catch (error) {
+        console.error('Failed to list skill folders for reconciliation.', error);
+      }
+      const reconciledImportedSkillFolders = reconcileImportedSkillFolders(
+        normalized.importedSkillFolders,
+        actualSkillFolders
+      );
+      const reconciled: GlobalData = {
+        ...normalized,
+        importedSkillFolders: reconciledImportedSkillFolders
+      };
+      globalData.value = reconciled;
       const shouldPersist =
         !stored ||
         !Array.isArray(stored.installedSkills) ||
         !Array.isArray(stored.installedPlugins) ||
-        !Array.isArray(stored.importedSkillFolders);
+        !Array.isArray(stored.importedSkillFolders) ||
+        !sameNumberArray(normalized.installedSkills, reconciled.installedSkills) ||
+        !sameNumberArray(normalized.installedPlugins, reconciled.installedPlugins) ||
+        !sameImportedSkillFolders(normalized.importedSkillFolders, reconciled.importedSkillFolders);
       if (shouldPersist) {
-        await writeAppData(GLOBAL_DATA_PATH, normalized);
+        await writeAppData(GLOBAL_DATA_PATH, reconciled);
       }
       loadedGlobal.value = true;
     } catch (error) {
@@ -114,21 +68,11 @@ export const useGlobalStore = defineStore('global', () => {
     }
   };
 
-  /**
-   * 强制刷新全局数据，忽略已加载状态。
-   * 输入：无。
-   * 输出：更新 globalData；失败时记录错误信息。
-   */
   const refreshGlobalData = async () => {
     loadedGlobal.value = false;
     await hydrate();
   };
 
-  /**
-   * 持久化全局数据。
-   * 输入：无（使用当前 globalData）。
-   * 输出：无；失败时记录错误。
-   */
   const persistGlobalData = async () => {
     try {
       await writeAppData(GLOBAL_DATA_PATH, normalizeGlobalData(globalData.value));

--- a/src/features/skills/skillsBridge.ts
+++ b/src/features/skills/skillsBridge.ts
@@ -6,10 +6,22 @@ export type SkillFolderImportResult = {
   destPath: string;
 };
 
+export type SkillFolderRecord = {
+  name: string;
+  path: string;
+};
+
 export type ProjectSkillLink = {
   name: string;
   linkPath: string;
   targetPath: string;
+};
+
+export const listSkillFolders = async (): Promise<SkillFolderRecord[] | null> => {
+  if (!isTauri()) {
+    return null;
+  }
+  return invoke<SkillFolderRecord[]>('skills_list_folders');
 };
 
 export const importSkillFolder = async (): Promise<SkillFolderImportResult | null> => {

--- a/src/tests/globalData.spec.ts
+++ b/src/tests/globalData.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeImportedSkillFolders,
+  reconcileImportedSkillFolders,
+  sameImportedSkillFolders
+} from '@/features/global/globalData';
+
+describe('reconcileImportedSkillFolders', () => {
+  it('adds folders found on disk but missing from the registry', () => {
+    const reconciled = reconcileImportedSkillFolders(
+      [],
+      [{ name: 'token-compact', path: 'C:\\skills\\token-compact' }],
+      123
+    );
+
+    expect(reconciled).toEqual([
+      {
+        id: 'C:\\skills\\token-compact',
+        name: 'token-compact',
+        path: 'C:\\skills\\token-compact',
+        addedAt: 123
+      }
+    ]);
+  });
+
+  it('preserves metadata by name while updating stale paths', () => {
+    const reconciled = reconcileImportedSkillFolders(
+      [
+        {
+          id: '\\\\?\\E:\\old\\token-compact',
+          name: 'token-compact',
+          path: '\\\\?\\E:\\old\\token-compact',
+          addedAt: 456
+        }
+      ],
+      [
+        {
+          name: 'token-compact',
+          path: 'C:\\Users\\will\\AppData\\Roaming\\com.golutra\\skills\\token-compact'
+        }
+      ],
+      999
+    );
+
+    expect(reconciled).toEqual([
+      {
+        id: 'C:\\Users\\will\\AppData\\Roaming\\com.golutra\\skills\\token-compact',
+        name: 'token-compact',
+        path: 'C:\\Users\\will\\AppData\\Roaming\\com.golutra\\skills\\token-compact',
+        addedAt: 456
+      }
+    ]);
+  });
+
+  it('drops registry entries that no longer exist on disk', () => {
+    const reconciled = reconcileImportedSkillFolders(
+      [
+        {
+          id: 'C:\\skills\\old-skill',
+          name: 'old-skill',
+          path: 'C:\\skills\\old-skill',
+          addedAt: 1
+        }
+      ],
+      [],
+      999
+    );
+
+    expect(reconciled).toEqual([]);
+  });
+});
+
+describe('global data helpers', () => {
+  it('normalizes imported folders and keeps equality strict', () => {
+    const normalized = normalizeImportedSkillFolders([
+      {
+        name: 'token-compact',
+        path: 'C:\\skills\\token-compact',
+        addedAt: 1
+      },
+      {
+        name: 'token-compact',
+        path: 'C:\\skills\\token-compact',
+        addedAt: 2
+      }
+    ]);
+
+    expect(normalized).toEqual([
+      {
+        id: 'C:\\skills\\token-compact',
+        name: 'token-compact',
+        path: 'C:\\skills\\token-compact',
+        addedAt: 1
+      }
+    ]);
+    expect(sameImportedSkillFolders(normalized, normalized)).toBe(true);
+    expect(sameImportedSkillFolders(normalized, [{ ...normalized[0], addedAt: 2 }])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a backend `skills_list_folders` command that enumerates the real global skill library on disk
- reconcile `importedSkillFolders` from that disk snapshot during startup and manual refresh
- repair stale registry entries by matching existing skills by name, so moved libraries can recover without manual re-import
- cover the reconcile rules with a focused Vitest spec

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `corepack pnpm exec vitest run src/tests/globalData.spec.ts`
- `corepack pnpm exec eslint "src/features/global/globalStore.ts" "src/features/global/globalData.ts" "src/tests/globalData.spec.ts" "src/features/skills/skillsBridge.ts"`

## Notes
- `corepack pnpm test -- src/tests/globalData.spec.ts` still surfaced an existing unrelated failure in `src/tests/chat-utils.spec.ts`; this PR does not touch that path.

## Contribution Capacity

- [x] This contribution is submitted in my personal capacity.
- [ ] This contribution is submitted on behalf of an organization that already has a signed CCLA on file.

Organization name: None
Authorization reference: None

## Required Declarations

- [x] I have the legal right to submit this contribution.
- [x] I understand accepted contributions may be used under the repository's documented BSL, change-license, and commercial licensing model.
- [x] I have disclosed below any third-party, copied, or adapted code and the relevant source/license details.
- [x] I have reviewed any AI-assisted output included in this PR and confirmed that I have the right to submit it.
- [x] I understand that undisclosed or incompatible third-party code may cause this PR to be rejected or later removed.

## Third-Party / Copied / Adapted Code Disclosure

None.

## AI Assistance Disclosure

Prepared with AI assistance and reviewed before submission.

## Co-author Disclosure

None.